### PR TITLE
chore: Update the bot so that it works with latest version of Stumble…

### DIFF
--- a/StumbleBot.au3
+++ b/StumbleBot.au3
@@ -33,6 +33,11 @@ Func _Main()
 		If DetectStumblePassLevelUp($hWnd) = 1 Or DetectStumbleJourneyLevelUp($hWnd) = 1 Then
 			ClickContinue()	
 		EndIf
+		
+		; Skip the advert
+		If DetectAdvert($hWnd) = 1 Then
+			ClickAdvertClose()	
+		EndIf
 
 		; Skip the item received screen
 		If DetectItemReceived($hWnd) = 1 Then
@@ -191,6 +196,12 @@ Func ClickOK()
 	_LeftClick($x, $y)
 EndFunc
 
+Func ClickAdvertClose()
+	$x = Random(1553, 1563)
+	$y = Random(124, 134)
+	_LeftClick($x, $y)
+EndFunc
+
 Func DetectMainMenu(ByRef $hWnd)
 	; (Yellow Play Button)
 	$c1 = PixelGetColor(1873, 921, $hWnd)
@@ -298,6 +309,33 @@ Func DetectItemReceived(ByRef $hWnd)
 	
 	; All of them should match
 	If $hex = "FFFFFF" And  $hex2 = "7E1CB8" And $hex3 = "55DB1E" And $hex4 = "0D88EC" Then Return 1
+
+	Return 0
+EndFunc
+
+Func DetectAdvert(ByRef $hWnd)
+	; (Green bottom left purchase button)
+	$c1 = PixelGetColor(719, 919, $hWnd)
+	$hex = Hex($c1, 6)
+	
+	; (Green bottom rifgt purchase button)
+	$c2 = PixelGetColor(1167, 919, $hWnd)
+	$hex2 = Hex($c2, 6)
+	
+	; (Purple top left)
+	$c3 = PixelGetColor(335, 156, $hWnd)
+	$hex3 = Hex($c3, 6)
+	
+	; (Pink bottom right)
+	$c4 = PixelGetColor(1581, 932, $hWnd)
+	$hex4 = Hex($c4, 6)
+	
+	; (Red x button)
+	$c5 = PixelGetColor(1557, 103, $hWnd)
+	$hex5 = Hex($c5, 6)
+	
+	; All of them should match
+	If $hex = "B1FB76" And  $hex2 = "7AB068" And $hex3 = "152ED2" And $hex4 = "CE4F8E" And $hex5 = "F45731" Then Return 1
 
 	Return 0
 EndFunc

--- a/helper_script.py
+++ b/helper_script.py
@@ -1,0 +1,46 @@
+from pynput import mouse, keyboard
+from PIL import ImageGrab
+import sys
+
+# Flag to control the script's running state
+running = True
+
+def rgb_to_hex(rgb):
+    """Convert an RGB tuple to a hex color string"""
+    return '#{:02x}{:02x}{:02x}'.format(rgb[0], rgb[1], rgb[2]).upper()
+
+def on_click(x, y, button, pressed):
+    """Mouse click listener"""
+    if button == mouse.Button.right and pressed:
+        try:
+            screenshot = ImageGrab.grab(all_screens=True)
+            # Get the pixel color at (x, y)
+            rgb = screenshot.getpixel((x, y))
+            hex_color = rgb_to_hex(rgb)
+            print(f"Right mouse button pressed at X: {x}, Y: {y}, RGB: {rgb}, HEX: {hex_color}")
+        except IndexError:
+            print(f"Right mouse button pressed at X: {x}, Y: {y}, but coordinates are outside the screen bounds.")
+
+def on_press(key):
+    """Key press listener"""
+    global running
+    if key == keyboard.Key.space:
+        print("Spacebar pressed. Exiting...")
+        running = False
+        return False
+
+# Set up the mouse listener
+mouse_listener = mouse.Listener(on_click=on_click)
+mouse_listener.start()
+
+# Set up the keyboard listener
+keyboard_listener = keyboard.Listener(on_press=on_press)
+keyboard_listener.start()
+
+# Keep the script running until the spacebar is pressed
+while running:
+    pass
+
+# Stop the listeners
+mouse_listener.stop()
+keyboard_listener.stop()


### PR DESCRIPTION
Bot did not exit after the first round loss, it would spectate for the following 2 rounds. The "Leave" button can no longer be clicked, the escape keypress is used to exit after the loss. So, F10 is now used to kill the bot instead of the escape key. The bot also did not handle the Stumble Pass and Stumble Journey rewards, so code has been added to detect those screens and proceed.